### PR TITLE
language not case sensitive for getCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "build": "babel src --out-dir build",
-    "test": "mocha --require babel-core/register"
+    "test": "mocha --require babel-core/register --harmony_array_includes"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default class ISO6391 {
 
   static getCode = (name) => {
     const [code] = Object.entries(LANGUAGES_LIST)
-      .find(([code, language]) => language.name === name || language.nativeName === name)
+      .find(([code, language]) => language.name.toLowerCase() === name.toLowerCase() || language.nativeName.toLowerCase() === name.toLowerCase())
 
     return code === undefined ? '' : code
   }


### PR DESCRIPTION
Added .toLowerCase to allow getCode(), passing 'english' or 'English' to return 'en'