### PR TITLE
move babel-runtime to dependencies group

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-0": "^6.16.0",
-    "babel-runtime": "^6.18.0",
     "mocha": "^3.1.2"
   },
   "homepage": "https://github.com/meikidd/iso-639-1#readme",
   "engines": {
     "node": ">=6.0"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.18.0"
   }
 }


### PR DESCRIPTION
move babel-runtime to dependencies group