### PR TITLE
Object.values and Array.find written with older browser support in mind

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,26 @@
 import LANGUAGES_LIST from './data';
 
+function objectValues(object) {
+  const result = [];
+  for (const key of object) {
+    if (object.hasOwnProperty(key)) {
+      result.push(object[key]);
+    }
+  }
+  return result;
+}
+
+function arrayFind(array, fn) {
+  const len = array.length;
+  for (let i=0; i < len; i++) {
+    const item = array[i];
+    if (fn(item)) {
+      return item;
+    }
+  }
+  return undefined;
+}
+
 export default class ISO6391 {
   static getLanguages(codes = []) {
     return codes.map(code => ({
@@ -14,7 +35,7 @@ export default class ISO6391 {
   }
 
   static getAllNames() {
-    return Object.values(LANGUAGES_LIST).map(l => l.name);
+    return objectValues(LANGUAGES_LIST).map(l => l.name);
   }
 
   static getNativeName(code) {
@@ -22,11 +43,11 @@ export default class ISO6391 {
   }
 
   static getAllNativeNames() {
-    return Object.values(LANGUAGES_LIST).map(l => l.nativeName);
+    return objectValues(LANGUAGES_LIST).map(l => l.nativeName);
   }
 
   static getCode(name) {
-    const code = Object.keys(LANGUAGES_LIST).find(code => {
+    const code = arrayFind(Object.keys(LANGUAGES_LIST), code => {
       const language = LANGUAGES_LIST[code];
 
       return (

--- a/test/test.js
+++ b/test/test.js
@@ -74,3 +74,15 @@ describe('getLanguages()', function() {
     ]);
   });
 });
+
+describe('getAllNames()', function() {
+  it('returns a nonempty array', function() {
+    assert(0 < ISO6391.getAllNames().length);
+  });
+});
+
+describe('getAllNativeNames()', function() {
+  it('returns a nonempty array', function() {
+    assert(0 < ISO6391.getAllNativeNames().length);
+  });
+});


### PR DESCRIPTION
After removing the polyfills, I suspect that calls to Object.values and Array.find will be broken in some browsers. Object.values is a developing spec, and Array.find isn't in IE11. These are hand-written replacements that should work well enough for the usage here. Also added some tests for the getAll* methods.