### PR TITLE
TS Export as default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,5 +16,5 @@ declare module "iso-639-1" {
 
   let localeCode: ISO6391;
 
-  export = localeCode;
+  export default localeCode;
 }


### PR DESCRIPTION
I had to change the ts definition slightly to get it to work, since ISO6391 exports default. Basic usage in typescript is:

```typescript
import ISO6391 from "iso-639-1";

ISO6391.getNativeName(...);
// etc.
```