### PR TITLE
Corrected native names of Indonesia (Indonesian) and Malaysia (Malay)

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -261,7 +261,7 @@ const LANGUAGES_LIST = {
   },
   id: {
     name: 'Indonesian',
-    nativeName: 'Indonesian',
+    nativeName: 'Bahasa Indonesia',
   },
   ie: {
     name: 'Interlingue',
@@ -429,7 +429,7 @@ const LANGUAGES_LIST = {
   },
   ms: {
     name: 'Malay',
-    nativeName: 'هاس ملايو‎',
+    nativeName: 'Bahasa Malaysia',
   },
   mt: {
     name: 'Maltese',


### PR DESCRIPTION
Hi there @meikidd !

Thank you so much for coming up with such an awesome npm package!

I am wondering if you could merge this PR so that the native names of [Indonesia](https://en.wikipedia.org/wiki/Indonesian_language) and [Malaysia](https://en.wikipedia.org/wiki/Malay_language) are up to date? 

I believe that this data was scrapped quite a long time ago. So, it would be great if these 2 languages' latest native names could be reflected in this package.

谢谢您！辛苦了 :)