### PR TITLE
Tibetan Standard -> Tibetan

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -76,7 +76,7 @@ const LANGUAGES_LIST = {
     nativeName: 'বাংলা',
   },
   bo: {
-    name: 'Tibetan Standard',
+    name: 'Tibetan',
     nativeName: 'བོད་ཡིག',
   },
   br: {


### PR DESCRIPTION
According to the [ISO standard](https://www.loc.gov/standards/iso639-2/php/code_list.php), Tibetan is classified as just Tibetan.

Indeed, [Wikipedia](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) specified that Tibetan is also known as Standard Tibetan, but I don't find any particular reason not to use just Tibetan while giving up consistency with the ISO.