### PR TITLE
Slovene -> Slovenian

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -576,7 +576,7 @@ const LANGUAGES_LIST = {
     nativeName: 'slovenčina',
   },
   sl: {
-    name: 'Slovene',
+    name: 'Slovenian',
     nativeName: 'slovenski jezik',
   },
   sm: {


### PR DESCRIPTION
EDIT: Add description.

The [ISO standard](https://www.loc.gov/standards/iso639-2/php/code_list.php) defines Slovenian as the English name of the Slovenian language. slovène, on the other hand, is the French name of Slovenian language.

![image](https://user-images.githubusercontent.com/37762634/105357911-6fdef380-5c30-11eb-9ef3-6aca0d8b1dc0.png)

Note that *slovène* is not capitalised since French follows a capitalisation rule that differs from English.