### PR TITLE
Hungarian native name fix

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -245,7 +245,7 @@ const LANGUAGES_LIST = {
   },
   hu: {
     name: 'Hungarian',
-    nativeName: 'Magyar',
+    nativeName: 'magyar',
   },
   hy: {
     name: 'Armenian',


### PR DESCRIPTION
Hi,

In Hungarian, language names are not capitalized therefore the word `Hungarian` is spelled as `magyar` not `Magyar`.

Thanks,
Laszlo