### PR TITLE
Polish language native name fix

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -513,7 +513,7 @@ const LANGUAGES_LIST = {
   },
   pl: {
     name: 'Polish',
-    nativeName: 'język polski',
+    nativeName: 'Polski',
   },
   ps: {
     name: 'Pashto',


### PR DESCRIPTION
To stick to one naming convention it should be "Polski" instead "język polski"