### PR TITLE
Fix Slovenian native name

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -577,7 +577,7 @@ const LANGUAGES_LIST = {
   },
   sl: {
     name: 'Slovenian',
-    nativeName: 'slovenski jezik',
+    nativeName: 'slovenščina',
   },
   sm: {
     name: 'Samoan',


### PR DESCRIPTION
Hello! I have updated the Slovenian language's native name to be the more natural alternative.