### PR TITLE
Make validate a type guard

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,7 @@ declare module 'iso-639-1' {
     getAllNativeNames: () => Array<string>;
     getCode: (name: string) => LanguageCode;
     getAllCodes: () => Array<LanguageCode>;
-    validate: (code: string) => boolean;
+    validate: (code: string) => code is LanguageCode;
     getLanguages: (codes: Array<string>) => Array<{
       code: LanguageCode;
       name: string;


### PR DESCRIPTION
As `validate` returns a boolean, we can use it to refine the type.