### PR TITLE
Capitialize Danish native

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -121,7 +121,7 @@ const LANGUAGES_LIST = {
   },
   da: {
     name: 'Danish',
-    nativeName: 'dansk',
+    nativeName: 'Dansk',
   },
   de: {
     name: 'German',


### PR DESCRIPTION
Danish native in the used context are spelled 'Dansk'