### PR TITLE
Ukrainian Alpha-2 code changed from UK to UA

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -675,7 +675,7 @@ const LANGUAGES_LIST = {
     name: 'Uyghur',
     nativeName: 'ئۇيغۇرچە‎',
   },
-  uk: {
+  ua: {
     name: 'Ukrainian',
     nativeName: 'Українська',
   },


### PR DESCRIPTION
UK is incorrect ISO Alpha-2 code for Ukrainian language:
- https://en.wikipedia.org/wiki/ISO_3166-2:UA
- https://www.iso.org/obp/ui/#iso:code:3166:UA