### PR TITLE
ISO6391.validate() type predicate

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,7 @@ declare module 'iso-639-1' {
     getAllNativeNames: () => Array<string>;
     getCode: (name: string) => LanguageCode | "";
     getAllCodes: () => Array<LanguageCode>;
-    validate: (code: string) => boolean;
+    validate: (code: string) => code is LanguageCode;
     getLanguages: (codes: Array<string>) => Array<{
       code: LanguageCode;
       name: string;


### PR DESCRIPTION
Adds a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to `ISO6391.validate()`, so you can do this:

```ts
if (ISO6391.validate(lang)) {
  lang; // type is LanguageCode
}
```

The current behavior without this change is like this:

```ts
if (ISO6391.validate(lang)) {
  lang; // type is string
}
```

This is useful for working with the `LanguageCode` type throughout a project, like when functions only accept a LanguageCode parameter, or a function needs to return a LanguageCode.

Currently type assertion is required: `as LanguageCode`. After this change it would not be.

For example:

```diff
function iso6393To6391(iso6393: string): LanguageCode | undefined {
  const locale = new Intl.Locale(iso6393);

  if (ISO6391.validate(locale.language)) {
-   return locale.language as LanguageCode;
+   return locale.language;
  }
}
```